### PR TITLE
choose newest version as default

### DIFF
--- a/libraries/provider_package.rb
+++ b/libraries/provider_package.rb
@@ -70,7 +70,7 @@ class Chef
           available_info = shell_out!("pkgin avail | grep ^#{package}-[0-9] | awk '{ print $1 }'", :env => nil, :returns => [0,1])
           
           unless available_info.nil? || available_info.stdout.empty?
-            candidate_info = available_info.stdout.split(/(-[0-9])/)
+            candidate_info = available_info.stdout.split.last.split(/(-[0-9])/)
             candidate_name = candidate_info[0]
             candidate_version = (candidate_info[1]+candidate_info[2]).chop.reverse.chop.reverse
           end


### PR DESCRIPTION
HI.
pkgin cookbook  is useful for managing smartos.

I want to use newest package version when version not defined.

example)

if many versions shown in pkgin, pick up version from  last row.
- mysql-server-5.0.96
- mysql-server-5.1.63
- mysql-server-5.5.25

In this case. Chef-client will install mysql-server-5.5.25. 

II have tested on smartos base64 version 1.8.4.
